### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 A configuration management framework written in Go.
 
+## v0.5.0
+
+### Added
+
+- A new `User` resource for managing users and groups
+- A new `Service` resource for managing systemd services
+- A new `Archive` resource for extracting tar and zip archives, with strip and
+  pick options for pulling single binaries out of release tarballs
+- A new `Template` resource for rendering Go templates from disk
+- A new `Sysctl` resource for writing and applying kernel parameters
+- A new `Line` resource for editing individual lines in a file that isn't fully
+  managed by `File`
+- A `Lock` option on the `Execute` resource, and an `ExecLocked` helper, for
+  taking the global lock
+- Locked apt and dpkg helpers: `DistUpgrade`, `AptAutoremove`, `AptHold` and
+  `InstallDeb`
+- Docker-based integration tests that run across Ubuntu, Debian, Fedora and Arch
+
+### Changed
+
+- Pinned GitHub Actions to commit SHAs and restricted the workflow token
+  permissions
+
 ## v0.3.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ go build -o viaduct
 
 See the example in the [examples](examples/basic) directory.
 
+## Resources
+
+The [resources](https://pkg.go.dev/github.com/surminus/viaduct/resources)
+package covers the common building blocks:
+
+- `File`, `Directory` and `Link` for files, directories and symlinks
+- `Template` for rendering Go templates from disk to a file
+- `Line` for editing individual lines in a file that isn't fully managed
+- `Package` and `Apt` for installing packages and managing apt repositories
+- `User` for users and groups, and `Service` for systemd units
+- `Archive` for extracting tar and zip archives
+- `Sysctl` for writing and applying kernel parameters
+- `Download` and `Git` for fetching files and cloning repositories
+- `Execute` for running arbitrary commands
+
+Most resources have shortcut constructors, such as `resources.Dir`,
+`resources.Pkg` and `resources.SystemUser`. See the package docs for the full
+set.
+
 ## CLI
 
 The compiled binary comes with runtime flags:


### PR DESCRIPTION
Release prep for v0.5.0. Two doc changes: a changelog entry covering the new resources, the Execute lock, the apt helpers and the integration tests, and a short rundown of the available resources in the README so people aren't digging through pkg.go.dev to see what exists.

I didn't backfill the changelog for v0.3.2 to v0.4.0 since that gap was never written up, so v0.5.0 picks up from v0.3.1.

Once this is merged I'll tag v0.5.0 off main and cut the release.
