### PR TITLE
Add Chain and on-demand parent directory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ func main() {
 }
 ```
 
+When you have a linear sequence where each resource depends on the previous
+one, you can wire the whole thing in a single call with `Chain` rather than
+declaring each dependency by hand:
+
+```go
+func main() {
+        m := viaduct.New()
+
+        // The file waits for the directory, and the symlink waits for the file
+        m.Chain(
+                &resources.Directory{Path: "/tmp/test"},
+                &resources.File{Path: "/tmp/test/foo"},
+                &resources.Link{Path: "/tmp/test/bar", Source: "/tmp/test/foo"},
+        )
+}
+```
+
+`Chain` returns the created resources in order, so you can still branch other
+resources off any individual link.
+
 When you've added all the resources you need, we can apply them:
 
 ```go

--- a/manifest.go
+++ b/manifest.go
@@ -115,6 +115,35 @@ func (m *Manifest) Add(attributes ResourceAttributes, deps ...*Resource) *Resour
 	return r
 }
 
+// Chain adds a sequence of resources where each one depends on the resource
+// before it, wiring a -> b -> c in a single call. It returns the created
+// resources in the order they were given, so you can still branch off any
+// individual link.
+//
+// To hang a chain off a resource that already exists, wire the first link with
+// SetDep after the chain has been created:
+//
+//	chain := m.Chain(a, b, c)
+//	m.SetDep(chain[0], string(base.ResourceID))
+func (m *Manifest) Chain(attributes ...ResourceAttributes) []*Resource {
+	resources := make([]*Resource, 0, len(attributes))
+
+	var prev *Resource
+	for _, a := range attributes {
+		var r *Resource
+		if prev == nil {
+			r = m.Add(a)
+		} else {
+			r = m.Add(a, prev)
+		}
+
+		resources = append(resources, r)
+		prev = r
+	}
+
+	return resources
+}
+
 func attrJSON(a any) string {
 	str, err := json.MarshalIndent(a, "", "  ")
 	if err != nil {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -157,6 +157,50 @@ func TestAddResource(t *testing.T) {
 	})
 }
 
+func TestChain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wires each link to the previous one", func(t *testing.T) {
+		t.Parallel()
+
+		m := New()
+		chain := m.Chain(
+			newTestResource("a"),
+			newTestResource("b"),
+			newTestResource("c"),
+		)
+
+		assert.Len(t, chain, 3)
+
+		// The first link has no dependencies.
+		assert.Empty(t, chain[0].DependsOn)
+
+		// Each subsequent link depends only on the one before it.
+		assert.Equal(t, []ResourceID{chain[0].ResourceID}, chain[1].DependsOn)
+		assert.Equal(t, []ResourceID{chain[1].ResourceID}, chain[2].DependsOn)
+	})
+
+	t.Run("empty chain returns no resources", func(t *testing.T) {
+		t.Parallel()
+
+		m := New()
+		chain := m.Chain()
+
+		assert.Empty(t, chain)
+		assert.Empty(t, m.resources)
+	})
+
+	t.Run("single link has no dependencies", func(t *testing.T) {
+		t.Parallel()
+
+		m := New()
+		chain := m.Chain(newTestResource("only"))
+
+		assert.Len(t, chain, 1)
+		assert.Empty(t, chain[0].DependsOn)
+	})
+}
+
 func TestCollectFailures(t *testing.T) {
 	t.Parallel()
 

--- a/resources/download.go
+++ b/resources/download.go
@@ -19,6 +19,9 @@ type Download struct {
 
 	// NotIfExists will not download the file if it already exists
 	NotIfExists bool
+	// CreateDirIfMissing creates the parent directory if it does not already
+	// exist. The parent is created with 0755 and default ownership.
+	CreateDirIfMissing bool
 
 	// Permissions manages permissions for the downloaded content
 	Permissions
@@ -61,6 +64,12 @@ func (a *Download) Run(log *viaduct.Logger) error {
 
 func (a *Download) get(log *viaduct.Logger) error {
 	path := viaduct.ExpandPath(a.Path)
+
+	if a.CreateDirIfMissing {
+		if err := ensureParentDir(log, path); err != nil {
+			return err
+		}
+	}
 
 	if viaduct.Cli.DryRun {
 		log.Info("downloaded", "url", a.URL, "path", path)

--- a/resources/download_test.go
+++ b/resources/download_test.go
@@ -49,4 +49,42 @@ func TestDown(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("create with missing parent dir", func(t *testing.T) {
+		// Not parallel: gock intercepts the global transport, so running
+		// alongside the other gock-based subtest would clobber its mocks.
+		defer gock.Off()
+
+		testurl := "http://test-createp.com"
+
+		gock.New(testurl).
+			Get("/").
+			Reply(200).
+			BodyString("OK")
+
+		dir := "test/acceptance/download/createp"
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+
+		d := &Download{
+			URL:                testurl,
+			Path:               dir + "/nested/basic.txt",
+			CreateDirIfMissing: true,
+		}
+		if err := d.PreflightChecks(testLogger); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, false, viaduct.DirExists(dir))
+
+		err := d.Run(testLogger)
+		assert.NoError(t, err)
+
+		assert.Equal(t, true, viaduct.FileExists(d.Path))
+
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/resources/file.go
+++ b/resources/file.go
@@ -20,6 +20,10 @@ type File struct {
 	Content string
 	// Delete will delete the file rather than create it if set to true.
 	Delete bool
+	// CreateDirIfMissing creates the parent directory if it does not already
+	// exist, rather than relying on a separately declared Directory resource.
+	// The parent is created with 0755 and default ownership.
+	CreateDirIfMissing bool
 
 	// Permissions manages permissions for the file
 	Permissions
@@ -33,6 +37,13 @@ func Touch(path string) *File {
 // CreateFile writes content to the specified path
 func CreateFile(path, content string) *File {
 	return &File{Path: path, Content: content}
+}
+
+// CreateFileP writes content to the specified path, creating the parent
+// directory if it does not already exist. It is the equivalent of running
+// "mkdir -p" before writing the file.
+func CreateFileP(path, content string) *File {
+	return &File{Path: path, Content: content, CreateDirIfMissing: true}
 }
 
 // DeleteFile will delete the specified file
@@ -110,6 +121,12 @@ func (f *File) Run(log *viaduct.Logger) error {
 // Create creates or updates a file
 func (f *File) createFile(log *viaduct.Logger) error {
 	path := viaduct.ExpandPath(f.Path)
+
+	if f.CreateDirIfMissing {
+		if err := ensureParentDir(log, path); err != nil {
+			return err
+		}
+	}
 
 	if viaduct.Cli.DryRun {
 		log.Info("created", "path", path)

--- a/resources/file_test.go
+++ b/resources/file_test.go
@@ -43,6 +43,36 @@ func TestFile(t *testing.T) {
 		}
 	})
 
+	t.Run("create with missing parent dir", func(t *testing.T) {
+		t.Parallel()
+
+		dir := "test/acceptance/file/createp"
+		f := CreateFileP(dir+"/nested/create.txt", "Test Content")
+
+		err := f.PreflightChecks(testLogger)
+		assert.NoError(t, err)
+
+		// Clear any leftover state from an interrupted previous run so the
+		// precondition below is reliable.
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+
+		// The parent directory should not exist yet.
+		assert.Equal(t, false, viaduct.DirExists(dir))
+
+		err = f.Run(testLogger)
+		assert.NoError(t, err)
+
+		assert.Equal(t, true, viaduct.FileExists(f.Path))
+		assert.Equal(t, f.Content, viaduct.FileContents(f.Path))
+
+		err = os.RemoveAll(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	t.Run("delete", func(t *testing.T) {
 		t.Parallel()
 

--- a/resources/link.go
+++ b/resources/link.go
@@ -18,6 +18,10 @@ type Link struct {
 	Source string
 	// Delete will delete the symlink.
 	Delete bool
+	// CreateDirIfMissing creates the parent directory of the symlink if it
+	// does not already exist. The parent is created with 0755 and default
+	// ownership.
+	CreateDirIfMissing bool
 }
 
 // CreateLink will create a new symlink.
@@ -81,6 +85,12 @@ func (l *Link) createLink(log *viaduct.Logger) error {
 	}
 
 	path := viaduct.ExpandPath(l.Path)
+
+	if l.CreateDirIfMissing {
+		if err := ensureParentDir(log, path); err != nil {
+			return err
+		}
+	}
 
 	if viaduct.Cli.DryRun {
 		log.Info("created", "source", source, "path", path)

--- a/resources/link_test.go
+++ b/resources/link_test.go
@@ -38,6 +38,35 @@ func TestLink(t *testing.T) {
 		}
 	})
 
+	t.Run("create with missing parent dir", func(t *testing.T) {
+		t.Parallel()
+
+		dir := "test/acceptance/link/createp"
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+
+		l := &Link{
+			Source:             "test/acceptance/link/source.txt",
+			Path:               dir + "/nested/create.txt",
+			CreateDirIfMissing: true,
+		}
+		if err := l.PreflightChecks(testLogger); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, false, viaduct.DirExists(dir))
+
+		err := l.Run(testLogger)
+		assert.NoError(t, err)
+
+		assert.Equal(t, true, viaduct.LinkExists(l.Path))
+
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	t.Run("delete", func(t *testing.T) {
 		t.Parallel()
 

--- a/resources/template.go
+++ b/resources/template.go
@@ -24,6 +24,10 @@ type Template struct {
 	// variable that does not exist in this map is an error.
 	Variables map[string]string
 
+	// CreateDirIfMissing creates the parent directory of Dest if it does not
+	// already exist. The parent is created with 0755 and default ownership.
+	CreateDirIfMissing bool
+
 	// Permissions manages permissions for the rendered file
 	Permissions
 }
@@ -61,6 +65,12 @@ func (t *Template) OperationName() string {
 
 func (t *Template) Run(log *viaduct.Logger) error {
 	if viaduct.Cli.DryRun {
+		if t.CreateDirIfMissing {
+			if err := ensureParentDir(log, viaduct.ExpandPath(t.Dest)); err != nil {
+				return err
+			}
+		}
+
 		log.Info("created", "path", viaduct.ExpandPath(t.Dest))
 		return nil
 	}
@@ -77,7 +87,7 @@ func (t *Template) Run(log *viaduct.Logger) error {
 
 	// Delegate writing to the File resource, which handles content
 	// comparison and permissions
-	file := &File{Path: t.Dest, Content: content, Permissions: t.Permissions}
+	file := &File{Path: t.Dest, Content: content, CreateDirIfMissing: t.CreateDirIfMissing, Permissions: t.Permissions}
 
 	return file.createFile(log)
 }

--- a/resources/template_test.go
+++ b/resources/template_test.go
@@ -66,6 +66,20 @@ func TestTemplate(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("creates missing parent dir", func(t *testing.T) {
+		tmpl := newTestTemplate(t, "hello\n")
+		// Point Dest at a subdirectory that does not exist yet.
+		tmpl.Dest = filepath.Join(filepath.Dir(tmpl.Dest), "nested", "out")
+		tmpl.CreateDirIfMissing = true
+
+		err := tmpl.Run(testLogger)
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(tmpl.Dest)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello\n", string(content))
+	})
+
 	t.Run("missing source errors", func(t *testing.T) {
 		tmpl := newTestTemplate(t, "")
 		tmpl.Source = filepath.Join(t.TempDir(), "nonexistent")

--- a/resources/utils.go
+++ b/resources/utils.go
@@ -27,6 +27,34 @@ func lockPath(path string) func() {
 	return m.Unlock
 }
 
+// ensureParentDir creates the parent directory of the given path if it does
+// not already exist. It backs the CreateDirIfMissing option on the
+// path-writing resources, letting a resource make its own parent without a
+// separately declared Directory resource.
+//
+// The parent is created with 0755 and default ownership. If you need the
+// parent managed with specific permissions or ownership, declare a Directory
+// resource (or use Chain) instead. path is expected to be already expanded.
+func ensureParentDir(log *viaduct.Logger, path string) error {
+	dir := filepath.Dir(path)
+
+	if viaduct.DirExists(dir) {
+		return nil
+	}
+
+	if viaduct.Cli.DryRun {
+		log.Info("created-parent", "path", dir)
+		return nil
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	log.Info("created-parent", "path", dir)
+	return nil
+}
+
 // runCommand runs a system command, directing output according to the
 // CLI flags
 func runCommand(args ...string) error {

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -44,6 +44,18 @@ func main() {
 	file := m.Add(resources.CreateFile("/opt/viaduct-test/file", "hello\n"), dir)
 	m.Add(resources.CreateLink("/opt/viaduct-test/link", "/opt/viaduct-test/file"), file)
 
+	// Chain wires a linear sequence where each link depends on the one before
+	// it, instead of declaring each dependency by hand
+	m.Chain(
+		resources.Dir("/opt/viaduct-chain"),
+		resources.CreateFile("/opt/viaduct-chain/file", "chained\n"),
+		resources.CreateLink("/opt/viaduct-chain/link", "/opt/viaduct-chain/file"),
+	)
+
+	// CreateDirIfMissing creates the parent directory tree when it does not
+	// already exist, without a separately declared Directory resource
+	m.Add(resources.CreateFileP("/opt/viaduct-createp/nested/file", "created with parents\n"))
+
 	// Template rendering
 	tmpl := m.Add(resources.CreateFile("/opt/viaduct-test/greeting.tmpl", "Hello, {{.name}}!\n"), dir)
 	m.Add(&resources.Template{

--- a/test/integration/verify.sh
+++ b/test/integration/verify.sh
@@ -21,6 +21,14 @@ id -nG root | grep -qw daemon || fail "root not in daemon group"
 grep -q "^hello$" /opt/viaduct-test/file || fail "file content wrong"
 [ -L /opt/viaduct-test/link ] || fail "link missing"
 
+# Chain
+grep -q "^chained$" /opt/viaduct-chain/file || fail "chain file content wrong"
+[ -L /opt/viaduct-chain/link ] || fail "chain link missing"
+
+# CreateDirIfMissing
+[ -d /opt/viaduct-createp/nested ] || fail "createp parent dir not created"
+grep -q "^created with parents$" /opt/viaduct-createp/nested/file || fail "createp file content wrong"
+
 # Template
 grep -q "^Hello, viaduct!$" /opt/viaduct-test/greeting || fail "template not rendered"
 


### PR DESCRIPTION
Two ergonomic helpers that came out of using viaduct to build a dev environment.

Chain wires a linear sequence of resources where each one depends on the previous, in a single call. Add only takes dependencies one at a time, so chains like download then unzip then extract are easy to break by accidentally hanging every step off the same parent. Chain removes that footgun, and returns the resources in order so you can still branch off any individual link.

CreateDirIfMissing lets a path-writing resource (File, Template, Link, Download) create its own parent directory instead of relying on a separately declared Directory. That's the other thing that kept biting: a File racing ahead of the mkdir because it was wired to the wrong parent. CreateFileP is the shorthand, named after mkdir -p. The parent gets 0755 and default ownership, so if you want it properly managed you still declare a Directory or use Chain.

There's unit coverage for both, and they're exercised in the Docker integration run too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)