### PR TITLE
Add ChainFrom and ChainTo for composing chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,30 @@ func main() {
 ```
 
 `Chain` returns the created resources in order, so you can still branch other
-resources off any individual link.
+resources off any individual link. The returned value also has `Last` and
+`First` helpers for safely grabbing the ends of the chain to depend on.
+
+To start a chain from a resource that already exists, use `ChainFrom`:
+
+```go
+func main() {
+        m := viaduct.New()
+
+        base := m.Add(&resources.Directory{Path: "/tmp/test"})
+
+        // The file depends on base, and the link depends on the file
+        chain := m.ChainFrom(base,
+                &resources.File{Path: "/tmp/test/foo"},
+                &resources.Link{Path: "/tmp/test/bar", Source: "/tmp/test/foo"},
+        )
+
+        // This runs only once the whole chain above has completed
+        m.Add(&resources.File{Path: "/tmp/test/done"}, chain.Last())
+}
+```
+
+`ChainTo` is the mirror of `ChainFrom`: it makes an existing resource run after
+the chain by wiring it onto the chain's last link for you.
 
 When you've added all the resources you need, we can apply them:
 

--- a/manifest.go
+++ b/manifest.go
@@ -115,20 +115,47 @@ func (m *Manifest) Add(attributes ResourceAttributes, deps ...*Resource) *Resour
 	return r
 }
 
+// ResourceChain is the ordered sequence of resources returned by Chain,
+// ChainFrom and ChainTo. Within the chain each resource depends on the one
+// before it; the first resource additionally depends on the resource passed
+// to ChainFrom, if any.
+type ResourceChain []*Resource
+
+// Last returns the final resource in the chain, or nil if the chain is empty.
+// It's the usual thing to depend on when wiring more work after a chain.
+func (c ResourceChain) Last() *Resource {
+	if len(c) == 0 {
+		return nil
+	}
+
+	return c[len(c)-1]
+}
+
+// First returns the first resource in the chain, or nil if the chain is empty.
+func (c ResourceChain) First() *Resource {
+	if len(c) == 0 {
+		return nil
+	}
+
+	return c[0]
+}
+
 // Chain adds a sequence of resources where each one depends on the resource
 // before it, wiring a -> b -> c in a single call. It returns the created
-// resources in the order they were given, so you can still branch off any
-// individual link.
+// resources in order, so you can still branch off any individual link.
 //
-// To hang a chain off a resource that already exists, wire the first link with
-// SetDep after the chain has been created:
-//
-//	chain := m.Chain(a, b, c)
-//	m.SetDep(chain[0], string(base.ResourceID))
-func (m *Manifest) Chain(attributes ...ResourceAttributes) []*Resource {
-	resources := make([]*Resource, 0, len(attributes))
+// To start a chain from a resource that already exists, use ChainFrom.
+func (m *Manifest) Chain(attributes ...ResourceAttributes) ResourceChain {
+	return m.ChainFrom(nil, attributes...)
+}
 
-	var prev *Resource
+// ChainFrom is like Chain, but the first resource in the chain depends on an
+// existing resource. from may be nil, in which case the chain has no initial
+// dependency and ChainFrom behaves exactly like Chain.
+func (m *Manifest) ChainFrom(from *Resource, attributes ...ResourceAttributes) ResourceChain {
+	resources := make(ResourceChain, 0, len(attributes))
+
+	prev := from
 	for _, a := range attributes {
 		var r *Resource
 		if prev == nil {
@@ -142,6 +169,24 @@ func (m *Manifest) Chain(attributes ...ResourceAttributes) []*Resource {
 	}
 
 	return resources
+}
+
+// ChainTo is like Chain, but an existing resource is made to depend on the
+// last resource in the chain, so it runs only once the whole chain has
+// completed. to may be nil, in which case ChainTo behaves exactly like Chain.
+//
+// The returned chain does not include to, mirroring how ChainFrom does not
+// include the resource it starts from.
+func (m *Manifest) ChainTo(to *Resource, attributes ...ResourceAttributes) ResourceChain {
+	chain := m.Chain(attributes...)
+
+	if to != nil {
+		if last := chain.Last(); last != nil {
+			m.SetDep(to, string(last.ResourceID))
+		}
+	}
+
+	return chain
 }
 
 func attrJSON(a any) string {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -201,6 +201,104 @@ func TestChain(t *testing.T) {
 	})
 }
 
+func TestChainFrom(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first link depends on the starting resource", func(t *testing.T) {
+		t.Parallel()
+
+		m := New()
+		base := m.Add(newTestResource("base"))
+		chain := m.ChainFrom(base,
+			newTestResource("a"),
+			newTestResource("b"),
+		)
+
+		assert.Len(t, chain, 2)
+		assert.Equal(t, []ResourceID{base.ResourceID}, chain[0].DependsOn)
+		assert.Equal(t, []ResourceID{chain[0].ResourceID}, chain[1].DependsOn)
+	})
+
+	t.Run("nil starting resource behaves like Chain", func(t *testing.T) {
+		t.Parallel()
+
+		m := New()
+		chain := m.ChainFrom(nil,
+			newTestResource("a"),
+			newTestResource("b"),
+		)
+
+		assert.Len(t, chain, 2)
+		assert.Empty(t, chain[0].DependsOn)
+		assert.Equal(t, []ResourceID{chain[0].ResourceID}, chain[1].DependsOn)
+	})
+}
+
+func TestChainTo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("target depends on the last link", func(t *testing.T) {
+		t.Parallel()
+
+		m := New()
+		target := m.Add(newTestResource("target"))
+		chain := m.ChainTo(target,
+			newTestResource("a"),
+			newTestResource("b"),
+		)
+
+		assert.Len(t, chain, 2)
+		assert.Empty(t, chain[0].DependsOn)
+		assert.Equal(t, []ResourceID{chain[0].ResourceID}, chain[1].DependsOn)
+
+		// The target is not part of the returned chain, but it now depends
+		// on the chain's last link.
+		stored := m.resources[target.ResourceID]
+		assert.Equal(t, []ResourceID{chain.Last().ResourceID}, stored.DependsOn)
+	})
+
+	t.Run("nil target behaves like Chain", func(t *testing.T) {
+		t.Parallel()
+
+		m := New()
+		chain := m.ChainTo(nil,
+			newTestResource("a"),
+			newTestResource("b"),
+		)
+
+		assert.Len(t, chain, 2)
+		assert.Empty(t, chain[0].DependsOn)
+		assert.Equal(t, []ResourceID{chain[0].ResourceID}, chain[1].DependsOn)
+	})
+}
+
+func TestResourceChain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first and last return the ends of the chain", func(t *testing.T) {
+		t.Parallel()
+
+		m := New()
+		chain := m.Chain(
+			newTestResource("a"),
+			newTestResource("b"),
+			newTestResource("c"),
+		)
+
+		assert.Equal(t, chain[0], chain.First())
+		assert.Equal(t, chain[2], chain.Last())
+	})
+
+	t.Run("first and last are nil for an empty chain", func(t *testing.T) {
+		t.Parallel()
+
+		var chain ResourceChain
+
+		assert.Nil(t, chain.First())
+		assert.Nil(t, chain.Last())
+	})
+}
+
 func TestCollectFailures(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A follow-up to Chain. The thing that kept coming up is that a chain almost always needs to start after some existing resource, and Chain couldn't do that, so you'd fall back to wiring each step by hand with Add.

ChainFrom takes an initial dependency, so the first link hangs off a resource that already exists. Pass nil and it behaves exactly like Chain.

ChainTo is the mirror: it makes an existing resource run after the whole chain, by wiring that resource onto the chain's last link. Also takes nil to behave like Chain.

Chain, ChainFrom and ChainTo now all return a ResourceChain, which is just a named []*Resource with nil-safe Last and First helpers so you can grab the end of a chain to depend on without indexing by hand. Chain is now a thin wrapper over ChainFrom(nil, ...).

The return type change from []*Resource to ResourceChain is source-compatible: a named slice type assigns to and from []*Resource freely, so existing callers still compile.

Unit tests cover the wiring for all three, plus the accessors, and the README has examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)